### PR TITLE
bugfix px exception in malformed cookie/header parsing

### DIFF
--- a/lib/perimeterx/internal/perimeter_x_context.rb
+++ b/lib/perimeterx/internal/perimeter_x_context.rb
@@ -26,6 +26,7 @@ module PxModule
           cookie_sym = "v#{exploded_token[0]}".to_sym
           @context[:px_cookie][cookie_sym] = exploded_token[1]
         else  # TOKEN_HEADER exists yet there's no ':' delimiter - may indicate an error (storing original value)
+          # TODO FIXME :px_cookie is expected to be a hash everywhere else; this will eventually raise an exception
           @context[:px_cookie] = req.headers[PxModule::TOKEN_HEADER]
         end
       elsif !cookies.empty? # Get cookie from jar

--- a/lib/perimeterx/internal/validators/perimeter_x_cookie_validator.rb
+++ b/lib/perimeterx/internal/validators/perimeter_x_cookie_validator.rb
@@ -86,7 +86,7 @@ module PxModule
         return true, px_ctx
       rescue Exception => e
         @logger.error("PerimeterxCookieValidator:[verify]: exception while verifying cookie => #{e.message}")
-        px_ctx.context[:px_orig_cookie] = cookie.px_cookie
+        px_ctx.context[:px_orig_cookie] = px_ctx.context[:px_cookie]
         px_ctx.context[:s2s_call_reason] = PxModule::COOKIE_DECRYPTION_FAILED
         return false, px_ctx
       end

--- a/spec/perimeter_x_cookie_validator_spec.rb
+++ b/spec/perimeter_x_cookie_validator_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe PxModule::PerimeterxCookieValidator, "Cookie Validator Tests" do
     verified, px_ctx = validator.verify(px_ctx)
     expect(verified).to eq false
     expect(px_ctx.context[:s2s_call_reason]).to eq PxModule::COOKIE_DECRYPTION_FAILED
-    expect(px_ctx.context[:px_orig_cookie]).to eq @req.cookies[:_px]
+    expect(px_ctx.context[:px_orig_cookie]).to eq(px_ctx.context[:px_cookie])
   end
 
   it "verification passed succesfully" do
@@ -97,6 +97,17 @@ RSpec.describe PxModule::PerimeterxCookieValidator, "Cookie Validator Tests" do
     verified, px_ctx = validator.verify(px_ctx)
     expect(px_ctx.context[:s2s_call_reason]).to eq PxModule::SENSITIVE_ROUTE 
     expect(verified).to eq false 
+  end
+
+  it "verification failed on malformed token header" do
+    @req.headers[PxModule::TOKEN_HEADER] = "SOME_MALFORMED_HEADER"
+    config = PxModule::Configuration.new(@params).configuration
+    px_ctx = PxModule::PerimeterXContext.new(config, @req)
+    validator = PxModule::PerimeterxCookieValidator.new(config)
+
+    verified, px_ctx = validator.verify(px_ctx)
+    expect(px_ctx.context[:s2s_call_reason]).to eq PxModule::COOKIE_DECRYPTION_FAILED
+    expect(verified).to eq false
   end
  
 


### PR DESCRIPTION
## Issue

(See PX chat for details: https://pxi.slack.com/archives/G4VL2KEMR/p1554778950052700)

v1.4.0 of the PX ruby enforcer raises an exception on malformed cookies since:
1) cookie parsing raises an exception and returns nil
2) the rescue block around that access a property on the nil cookie object, which raises an additional exception

As a result of that exception, request verification halts and the request is never sent to PX for scoring.

## Fix

This change just solves the additional exception by accessing the unparsed cookie value on the PX context object, which seems to be the intended behavior (accessing the unparsed original) anyway.

## Testing Done

I've verified this fix using `sneakers` locally and will defer to the PX team for a better long-term fix.

## Context

```
PerimeterxCookieValidator:[verify]: exception while verifying cookie => undefined method `key?' for "[]":String
/app/vendor/bundle/ruby/2.4.0/gems/perimeter_x-1.4.0/lib/perimeterx/internal/validators/perimeter_x_cookie_validator.rb:19:in `verify'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:382:in `block in make_lambda'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:169:in `block (2 levels) in halting'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:454:in `each'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:267:in `block (2 levels) in halting_and_conditional'
/app/app/controllers/concerns/delay_touching.rb:16:in `block in delay_touching'
/app/vendor/bundle/ruby/2.4.0/gems/perimeter_x-1.4.0/lib/perimeter_x.rb:117:in `verify'
/app/vendor/bundle/ruby/2.4.0/gems/perimeter_x-1.4.0/lib/perimeter_x.rb:18:in `px_verify_request'
/app/vendor/bundle/ruby/2.4.0/gems/actionpack-5.0.7.2/lib/abstract_controller/callbacks.rb:12:in `block (2 levels) in <module:Callbacks>'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:454:in `block in call'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:448:in `block (2 levels) in around'
/app/vendor/bundle/ruby/2.4.0/gems/perimeter_x-1.4.0/lib/perimeterx/internal/validators/perimeter_x_cookie_validator.rb:89:in `rescue in verify': undefined method `px_cookie' for nil:NilClass (NoMethodError)
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:454:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:101:in `__run_callbacks__'
/app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.7.2/lib/active_support/callbacks.rb:170:in `block in halting'
/app/vendor/bundle/ruby/2.4.0/bundler/gems/activerecord-delay_touching-90e0245fb188/lib/activerecord/delay_touching.rb:53:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/actionpack-5.0.7.2/lib/action_controller/metal/instrumentation.rb:30:in `process_action'
/app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.6/lib/rack/conditional_get.rb:38:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/newrelic_rpm-6.1.0.352/lib/new_relic/rack/agent_hooks.rb:30:in `traced_call'
/app/vendor/bundle/ruby/2.4.0/gems/actionpack-5.0.7.2/lib/action_dispatch/journey/router.rb:26:in `serve'
/app/vendor/bundle/ruby/2.4.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/debug_exceptions.rb:49:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/actionpack-5.0.7.2/lib/action_dispatch/middleware/callbacks.rb:38:in `block in call'
/app/vendor/bundle/ruby/2.4.0/gems/newrelic_rpm-6.1.0.352/lib/new_relic/agent/instrumentation/middleware_tracing.rb:99:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/newrelic_rpm-6.1.0.352/lib/new_relic/agent/instrumentation/middleware_tracing.rb:99:in `call'
/app/vendor/bundle/ruby/2.4.0/gems/rack-timeout-0.5.1/lib/rack/timeout/support/timeout.rb:19:in `timeout'
/app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.6/lib/rack/sendfile.rb:111:in `call'
```

still working through it, but it looks like something raises exception when calling `.key?`, probably here:
https://github.com/goatapp/perimeterx-ruby-sdk/blob/fbcacde8c5bf8c9ee9aa94acdd4d9d36b7f6b8a3/lib/perimeterx/internal/payload/perimeter_x_payload.rb#L15

this exception gets rescued here:
https://github.com/goatapp/perimeterx-ruby-sdk/blob/e7b0db9b96f3c91b85d81b96eebf5bb82a88c2a7/lib/perimeterx/internal/validators/perimeter_x_cookie_validator.rb#L87-L87

although it gets rescued, `cookie` is nil here: https://github.com/goatapp/perimeterx-ruby-sdk/blob/e7b0db9b96f3c91b85d81b96eebf5bb82a88c2a7/lib/perimeterx/internal/validators/perimeter_x_cookie_validator.rb#L89-L89

therefore, the rescue block also raises an exception

it looks like the value of the `:px_cookie` is set to be a string `"[]"` when it's expected to be a hash. we didn't log any of the headers, but I'm guessing that happens here: https://github.com/goatapp/perimeterx-ruby-sdk/blob/4dc0f477607217bf25263e181f753eb7fac6db2d/lib/perimeterx/internal/perimeter_x_context.rb#L29-L29

just tested locally -- I'm able to replicate this same behavior in v1.4.0 of the ruby enforcer by passing any malformed token into the px-authentication header

ex: make a request with `X-PX-AUTHORIZATION` = `[]` (in the case of the attack)